### PR TITLE
A master process should be forked in constructor

### DIFF
--- a/src/Snidel.php
+++ b/src/Snidel.php
@@ -72,6 +72,7 @@ class Snidel
         try {
             $this->container->enqueue(new Task($callable, $args, $tag));
         } catch (\RuntimeException $e) {
+            $this->log->error('failed to enqueue the task: ' . $e->getMessage());
             throw $e;
         }
 

--- a/src/Snidel.php
+++ b/src/Snidel.php
@@ -17,9 +17,6 @@ class Snidel
     /** @var \Ackintosh\Snidel\Fork\Container */
     private $container;
 
-    /** @var \Ackintosh\Snidel\Pcntl */
-    private $pcntl;
-
     /** @var \Ackintosh\Snidel\Log */
     private $log;
 
@@ -39,22 +36,7 @@ class Snidel
         $this->log = new Log($this->config->get('ownerPid'), $this->config->get('logger'));
         $this->container = new Container($this->config, $this->log);
         $this->container->forkMaster();
-        $this->pcntl = new Pcntl();
-
-        foreach ($this->signals as $sig) {
-            $this->pcntl->signal(
-                $sig,
-                function ($sig)  {
-                    $this->log->info('received signal. signo: ' . $sig);
-                    $this->log->info('--> sending a signal " to children.');
-                    $this->container->sendSignalToMaster($sig);
-                    $this->log->info('<-- signal handling has been completed successfully.');
-                    exit;
-                },
-                false
-            );
-        }
-
+        $this->registerSignalHandler($this->container, $this->log);
         $this->log->info('parent pid: ' . $this->config->get('ownerPid'));
     }
 
@@ -115,6 +97,28 @@ class Snidel
     public function getError()
     {
         return $this->container->getError();
+    }
+
+    /**
+     * @param Container $container
+     * @param Log $log
+     */
+    private function registerSignalHandler($container, $log)
+    {
+        $pcntl = new Pcntl();
+        foreach ($this->signals as $sig) {
+            $pcntl->signal(
+                $sig,
+                function ($sig) use ($log, $container) {
+                    $log->info('received signal. signo: ' . $sig);
+                    $log->info('--> sending a signal " to children.');
+                    $container->sendSignalToMaster($sig);
+                    $log->info('<-- signal handling has been completed successfully.');
+                    exit;
+                },
+                false
+            );
+        }
     }
 
     public function __destruct()

--- a/src/Snidel.php
+++ b/src/Snidel.php
@@ -31,12 +31,14 @@ class Snidel
 
     /**
      * @param   array $parameter
+     * @throws \RuntimeException
      */
     public function __construct($parameter = [])
     {
         $this->config = new Config($parameter);
         $this->log = new Log($this->config->get('ownerPid'), $this->config->get('logger'));
         $this->container = new Container($this->config, $this->log);
+        $this->container->forkMaster();
         $this->pcntl = new Pcntl();
 
         foreach ($this->signals as $sig) {
@@ -67,10 +69,6 @@ class Snidel
      */
     public function process($callable, $args = [], $tag = null)
     {
-        if (!$this->container->existsMaster()) {
-            $this->container->forkMaster();
-        }
-
         try {
             $this->container->enqueue(new Task($callable, $args, $tag));
         } catch (\RuntimeException $e) {

--- a/src/Snidel/Config.php
+++ b/src/Snidel/Config.php
@@ -16,7 +16,7 @@ class Config
         $default = [
             'concurrency'   => 5,
             // number of seconds to keep polling for results.
-            'duration' => 1,
+            'pollingDuration' => 1,
             'logger'        => null,
             'driver' => null,
         ];

--- a/src/Snidel/Config.php
+++ b/src/Snidel/Config.php
@@ -15,6 +15,8 @@ class Config
     {
         $default = [
             'concurrency'   => 5,
+            // number of seconds to keep polling for results.
+            'duration' => 1,
             'logger'        => null,
             'driver' => null,
         ];

--- a/src/Snidel/Fork/Container.php
+++ b/src/Snidel/Fork/Container.php
@@ -267,7 +267,7 @@ class Container
     {
         for (; $this->queuedCount() > $this->dequeuedCount();) {
             for (;;) {
-                if ($envelope = $this->resultQueue->dequeue()) {
+                if ($envelope = $this->resultQueue->dequeue($this->config->get('duration'))) {
                     $this->dequeuedCount++;
                     break;
                 }

--- a/src/Snidel/Fork/Container.php
+++ b/src/Snidel/Fork/Container.php
@@ -267,7 +267,7 @@ class Container
     {
         for (; $this->queuedCount() > $this->dequeuedCount();) {
             for (;;) {
-                if ($envelope = $this->resultQueue->dequeue($this->config->get('duration'))) {
+                if ($envelope = $this->resultQueue->dequeue($this->config->get('pollingDuration'))) {
                     $this->dequeuedCount++;
                     break;
                 }


### PR DESCRIPTION
Currently, a master process is forked on the first time of `Snidel::process()` call, which means there's a difference on calling `Snidel::process()` wheather it is the first time or not. 
I think that doesn't make sense. A master process should be forked in constructor. 💡 