### PR TITLE
Update opis/closure

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "bernard/bernard": "dev-master",
     "php": ">=5.6.0",
     "psr/log": "^1.0",
-    "opis/closure": "^2.1.0",
+    "opis/closure": "^3.0",
     "ext-pcntl": "*",
     "ext-shmop": "*",
     "ext-sysvshm": "*",


### PR DESCRIPTION
In some cases, opis/closure v2 throws `Exception: Serialization of 'Closure' is not allowed`.