### PR TITLE
Delete unnecessary requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,9 +16,6 @@
     "psr/log": "^1.0",
     "opis/closure": "^3.0.7",
     "ext-pcntl": "*",
-    "ext-shmop": "*",
-    "ext-sysvshm": "*",
-    "ext-sysvmsg": "*",
     "ext-posix": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Since https://github.com/ackintosh/snidel/pull/19, Snidel is using [Bernard](https://github.com/bernardphp/bernard) instead of SystemV shm/message queue.