### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ For details on the driver, please see [here](http://bernard.readthedocs.io/drive
 |:----------|:------------|
 | 0.1 ~ [0.8](https://github.com/ackintosh/snidel/releases/tag/0.8.0) | >= 5.3 |
 | [0.9](https://github.com/ackintosh/snidel/releases/tag/0.9.0) ~ | >= 5.6 |
+| upcoming new release ~ | >= 7.0 |
 
 ## Author
 


### PR DESCRIPTION
Snidel will drop support for PHP5 on upcoming new release.